### PR TITLE
MBTiles format control (jpg or png)

### DIFF
--- a/README
+++ b/README
@@ -8,5 +8,4 @@ python convert.py filename.mbtiles
 That's it! It should generate a folder called filename filled with PNGs that contain the data in the mbtiles archive.
 
 Notes:
-- I understand that some mbtiles files have JPGs, not PNG. I haven't bothered to detect that yet, though. I just write all of the files with a .png extension.
 - The Y axis values are set from a top left origin, which is TMS standard. This is not the default on many other mapping applications, like the google maps API or Leaflet, which require an option to use "TMS" scheme instead of "XYZ".

--- a/convert.py
+++ b/convert.py
@@ -35,15 +35,22 @@ os.makedirs(dirname)
 connection = sqlite3.connect(input_filename)
 cursor = connection.cursor()
 
+cursor.execute("SELECT value FROM metadata WHERE name='format'")
+img_format = cursor.fetchone()
+
+if img_format[0] == 'png':
+    out_format = '.png'
+elif img_format[0] == 'jpg':
+    out_format = '.jpg'
+
 # The mbtiles format helpfully provides a table that aggregates all necessary info
-cursor.execute('select * from tiles')
+cursor.execute('SELECT * FROM tiles')
 
 os.chdir(dirname)
 for row in cursor:
   setDir(str(row[0]))
   setDir(str(row[1]))
-  # TODO: Should we support jpg too?
-  output_file = open(str(row[2]) + '.png', 'wb')
+  output_file = open(str(row[2]) + out_format, 'wb')
   output_file.write(row[3])
   output_file.close()
   os.chdir('..')


### PR DESCRIPTION
Hello. I added some lines to control MBTiles images format (jpg or png). If you consider it right you can merge my pull request. In addition, since I wanted to make calls to functionality from other utilities inside a Python environment (not from command line), and keep clean your original project, I created a new project for that. I mention you as the original author of the command line utility:
https://github.com/cayetanobv/MBTiles-extractor-lib
Comments, changes or suggestions are welcome.
Thanks for all!
