### PR TITLE
Fixed bug: handled no metadata format info MBTiles

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -38,10 +38,13 @@ cursor = connection.cursor()
 cursor.execute("SELECT value FROM metadata WHERE name='format'")
 img_format = cursor.fetchone()
 
-if img_format[0] == 'png':
-    out_format = '.png'
-elif img_format[0] == 'jpg':
-    out_format = '.jpg'
+if img_format:
+    if img_format[0] == 'png':
+        out_format = '.png'
+    elif img_format[0] == 'jpg':
+        out_format = '.jpg'
+else:
+    out_format = ''
 
 # The mbtiles format helpfully provides a table that aggregates all necessary info
 cursor.execute('SELECT * FROM tiles')


### PR DESCRIPTION
When input MBTiles are not compliant with MBTiles Stable specification (1.1) an error occurs because MBTiles previous specification does not include key "format" in metadata table (_). I fixed it so that if a file is previous to current specification (1.1) and no format is specified, the output files does not have file extension (but output files work perfectly when they are opened in an image viewer).
(_) https://github.com/mapbox/mbtiles-spec
